### PR TITLE
[CREATE] #BTS-91 Novels 기능 수정 (요일, 등급)

### DIFF
--- a/src/main/java/com/readme/novels/novels/controller/AdminNovelsController.java
+++ b/src/main/java/com/readme/novels/novels/controller/AdminNovelsController.java
@@ -2,6 +2,7 @@ package com.readme.novels.novels.controller;
 
 import com.readme.novels.novels.dto.NovelsDto;
 import com.readme.novels.novels.dto.PaginationDto;
+import com.readme.novels.novels.dto.ResponseNovelsDto;
 import com.readme.novels.novels.requestObject.RequestAddNovels;
 import com.readme.novels.novels.dto.NovelsSearchParamDto;
 import com.readme.novels.novels.requestObject.RequestUpdateNovels;
@@ -71,7 +72,7 @@ public class AdminNovelsController {
     @GetMapping("/{id}")
     public ResponseEntity<CommonResponse<ResponseNovels>> getNovelsOne(@PathVariable Long id) {
 
-        NovelsDto novelsDto = novelsService.getNovelsById(id);
+        ResponseNovelsDto novelsDto = novelsService.getNovelsById(id);
 
         return ResponseEntity.ok().body(new CommonResponse(ResponseNovels.builder()
             .id(novelsDto.getId())
@@ -101,7 +102,7 @@ public class AdminNovelsController {
             .title(title)
             .build();
 
-        List<NovelsDto> novelsDtoList = novelsService.getNovels(novelsSearchParamDto);
+        List<ResponseNovelsDto> novelsDtoList = novelsService.getNovels(novelsSearchParamDto);
         PaginationDto paginationDto = novelsService.getPagination(novelsSearchParamDto);
 
         return ResponseEntity.ok(

--- a/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
@@ -4,6 +4,7 @@ import com.readme.novels.novels.model.Novels.Genre;
 import com.readme.novels.novels.model.Novels.Grade;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -24,7 +25,7 @@ public class NovelsDto {
     private String description;
     private String author;
     private Date startDate;
-    private Integer serializationDay;
+    private List<String> serializationDay;
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;

--- a/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
@@ -1,7 +1,6 @@
 package com.readme.novels.novels.dto;
 
 import com.readme.novels.novels.model.Novels.Genre;
-import com.readme.novels.novels.model.Novels.Grade;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
@@ -29,7 +28,7 @@ public class NovelsDto {
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;
-    private Grade grade;
+    private Integer grade;
     private Genre genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;

--- a/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
@@ -1,31 +1,37 @@
-package com.readme.novels.novels.responseObject;
+package com.readme.novels.novels.dto;
 
 import com.readme.novels.novels.model.Novels.Genre;
 import com.readme.novels.novels.model.Novels.Grade;
+import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Getter
 @Builder
+@Setter
+@ToString
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
-public class ResponseNovels {
+public class ResponseNovelsDto {
 
     private Long id;
     private String title;
-    private String author;
     private String description;
+    private String author;
     private Date startDate;
     private String serializationDay;
-    private String thumbnail;
     private String serializationStatus;
+    private String thumbnail;
     private String authorComment;
-
-    private Genre genre;
     private Grade grade;
+    private Genre genre;
+    private LocalDateTime createDate;
+    private LocalDateTime updateDate;
+
 }

--- a/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
@@ -1,10 +1,8 @@
 package com.readme.novels.novels.dto;
 
 import com.readme.novels.novels.model.Novels.Genre;
-import com.readme.novels.novels.model.Novels.Grade;
 import java.time.LocalDateTime;
 import java.util.Date;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,7 +27,7 @@ public class ResponseNovelsDto {
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;
-    private Grade grade;
+    private Integer grade;
     private Genre genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;

--- a/src/main/java/com/readme/novels/novels/model/Novels.java
+++ b/src/main/java/com/readme/novels/novels/model/Novels.java
@@ -33,9 +33,8 @@ public class Novels extends BaseTimeEntity {
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;
+    private Integer grade;
 
-    @Enumerated(EnumType.STRING)
-    private Grade grade;
     @Enumerated(EnumType.STRING)
     private Genre genre;
 
@@ -47,14 +46,6 @@ public class Novels extends BaseTimeEntity {
         드라마,
         로판,
         로맨스;
-    }
-
-    @Getter
-    public enum Grade {
-        AGE0,
-        AGE12,
-        AGE15,
-        AGE19;
     }
 
 }

--- a/src/main/java/com/readme/novels/novels/model/Novels.java
+++ b/src/main/java/com/readme/novels/novels/model/Novels.java
@@ -29,7 +29,7 @@ public class Novels extends BaseTimeEntity {
     private String description;
     private String author;
     private Date startDate;
-    private Integer serializationDay;
+    private String serializationDay;
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
@@ -3,6 +3,7 @@ package com.readme.novels.novels.requestObject;
 import com.readme.novels.novels.model.Novels.Genre;
 import com.readme.novels.novels.model.Novels.Grade;
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +21,7 @@ public class RequestAddNovels {
     private String description;
     private String author;
     private Date startDate;
-    private Integer serializationDay;
+    private List<String> serializationDay;
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
@@ -1,7 +1,6 @@
 package com.readme.novels.novels.requestObject;
 
 import com.readme.novels.novels.model.Novels.Genre;
-import com.readme.novels.novels.model.Novels.Grade;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -25,6 +24,6 @@ public class RequestAddNovels {
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;
-    private Grade grade;
+    private Integer grade;
     private Genre genre;
 }

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
@@ -3,6 +3,7 @@ package com.readme.novels.novels.requestObject;
 import com.readme.novels.novels.model.Novels.Genre;
 import com.readme.novels.novels.model.Novels.Grade;
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +22,7 @@ public class RequestUpdateNovels {
     private String description;
     private String author;
     private Date startDate;
-    private Integer serializationDay;
+    private List<String> serializationDay;
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
@@ -1,7 +1,6 @@
 package com.readme.novels.novels.requestObject;
 
 import com.readme.novels.novels.model.Novels.Genre;
-import com.readme.novels.novels.model.Novels.Grade;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -26,6 +25,6 @@ public class RequestUpdateNovels {
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;
-    private Grade grade;
+    private Integer grade;
     private Genre genre;
 }

--- a/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
+++ b/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
@@ -1,7 +1,6 @@
 package com.readme.novels.novels.responseObject;
 
 import com.readme.novels.novels.model.Novels.Genre;
-import com.readme.novels.novels.model.Novels.Grade;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,5 +26,5 @@ public class ResponseNovels {
     private String authorComment;
 
     private Genre genre;
-    private Grade grade;
+    private Integer grade;
 }

--- a/src/main/java/com/readme/novels/novels/service/NovelsService.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsService.java
@@ -3,6 +3,7 @@ package com.readme.novels.novels.service;
 import com.readme.novels.novels.dto.NovelsDto;
 import com.readme.novels.novels.dto.NovelsSearchParamDto;
 import com.readme.novels.novels.dto.PaginationDto;
+import com.readme.novels.novels.dto.ResponseNovelsDto;
 import java.util.List;
 
 public interface NovelsService {
@@ -13,9 +14,9 @@ public interface NovelsService {
 
     void deleteNovels(Long id);
 
-    NovelsDto getNovelsById(Long id);
+    ResponseNovelsDto getNovelsById(Long id);
 
-    List<NovelsDto> getNovels(NovelsSearchParamDto novelsSearchParamDto);
+    List<ResponseNovelsDto> getNovels(NovelsSearchParamDto novelsSearchParamDto);
 
     PaginationDto getPagination(NovelsSearchParamDto novelsSearchParamDto);
 }

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -2,6 +2,7 @@ package com.readme.novels.novels.service;
 
 import com.readme.novels.novels.dto.NovelsDto;
 import com.readme.novels.novels.dto.PaginationDto;
+import com.readme.novels.novels.dto.ResponseNovelsDto;
 import com.readme.novels.novels.model.Novels;
 import com.readme.novels.novels.repository.INovelsRepository;
 import com.readme.novels.novels.dto.NovelsSearchParamDto;
@@ -30,6 +31,13 @@ public class NovelsServiceImpl implements NovelsService {
             novelsDto.setSerializationStatus("연재중");
         }
 
+        List<String> serializationDays = novelsDto.getSerializationDay();
+        StringBuffer serialization = new StringBuffer();
+            serializationDays.forEach(item -> {
+                serialization.append(item + ",");
+        });
+
+
         Novels novels = Novels.builder()
             .title(novelsDto.getTitle())
             .author(novelsDto.getAuthor())
@@ -37,7 +45,7 @@ public class NovelsServiceImpl implements NovelsService {
             .genre(novelsDto.getGenre())
             .thumbnail(novelsDto.getThumbnail())
             .authorComment(novelsDto.getAuthorComment())
-            .serializationDay(novelsDto.getSerializationDay())
+            .serializationDay(serialization.toString().substring(0, serialization.length()-1))
             .startDate(novelsDto.getStartDate())
             .serializationStatus(novelsDto.getSerializationStatus())
             .description(novelsDto.getDescription())
@@ -55,13 +63,19 @@ public class NovelsServiceImpl implements NovelsService {
         iNovelsRepository.findById(novelsDto.getId()).orElseThrow(
             () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 소설입니다."));
 
+        List<String> serializationDays = novelsDto.getSerializationDay();
+        StringBuffer serialization = null;
+        serializationDays.forEach(item -> {
+            serialization.append(item + ",");
+        });
+
         Novels novels = Novels.builder()
             .id(novelsDto.getId())
             .genre(novelsDto.getGenre())
             .grade(novelsDto.getGrade())
             .startDate(novelsDto.getStartDate())
             .serializationStatus(novelsDto.getSerializationStatus())
-            .serializationDay(novelsDto.getSerializationDay())
+            .serializationDay(serialization.toString().substring(0, serialization.length()-1))
             .title(novelsDto.getTitle())
             .author(novelsDto.getAuthor())
             .thumbnail(novelsDto.getThumbnail())
@@ -94,12 +108,12 @@ public class NovelsServiceImpl implements NovelsService {
     }
 
     @Override
-    public NovelsDto getNovelsById(Long id) {
+    public ResponseNovelsDto getNovelsById(Long id) {
         Novels novels = iNovelsRepository.findById(id)
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 소설입니다."));
 
-        NovelsDto novelsDto = NovelsDto.builder()
+        ResponseNovelsDto novelsDto = ResponseNovelsDto.builder()
             .id(novels.getId())
             .serializationDay(novels.getSerializationDay())
             .serializationStatus(novels.getSerializationStatus())
@@ -120,14 +134,14 @@ public class NovelsServiceImpl implements NovelsService {
     }
 
     @Override
-    public List<NovelsDto> getNovels(NovelsSearchParamDto novelsSearchParamDto) {
+    public List<ResponseNovelsDto> getNovels(NovelsSearchParamDto novelsSearchParamDto) {
 
         List<Novels> novelsList = novelsRepository.getNovels(novelsSearchParamDto);
 
-        List<NovelsDto> novelsDtoList = new ArrayList<>();
+        List<ResponseNovelsDto> novelsDtoList = new ArrayList<>();
 
         novelsList.forEach(item -> {
-            NovelsDto novelsDto = NovelsDto.builder()
+            ResponseNovelsDto novelsDto = ResponseNovelsDto.builder()
                 .id(item.getId())
                 .title(item.getTitle())
                 .author(item.getAuthor())


### PR DESCRIPTION
1. 요일 (serializationDay) 저장 방식 변경
   - (기존) Integer -> (변경) String
   - 프론트에서 요청 보낼때는 체크박스(리스트), 저장 및 Read 할때는 String (ex. 월,화,수)
2. 등급 (grade) 저장 방식 변경
   - (기존) Enum -> (변경) Integer
   - Enum 타입 사용시 첫 글자를 숫자로 쓸 수 없어서 기존에는 AGE0, AGE12, AGE15, AGE19로 저장
   - Mongodb와 형태가 다르기 때문에 프론트에서 헷갈릴 수 있다고 판단해서 Integer 타입으로 변경