### PR TITLE
[UPDATE] #BTS-100/tag CRUD 및 코드 수정

### DIFF
--- a/src/main/java/com/readme/novels/novels/controller/AdminNovelsController.java
+++ b/src/main/java/com/readme/novels/novels/controller/AdminNovelsController.java
@@ -111,6 +111,7 @@ public class AdminNovelsController {
             .genre(novelsDto.getGenre())
             .grade(novelsDto.getGrade())
             .authorComment(novelsDto.getAuthorComment())
+            .tags(novelsDto.getTags())
             .build()));
     }
 
@@ -151,6 +152,7 @@ public class AdminNovelsController {
                     .genre(novelsDto.getGenre())
                     .grade(novelsDto.getGrade())
                     .authorComment(novelsDto.getAuthorComment())
+                    .tags(novelsDto.getTags())
                     .build()))
                 .pagination(Pagination.builder()
                     .page(paginationDto.getPage())

--- a/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
@@ -35,7 +35,11 @@ public class NovelsDto {
     private List<Tags> tags;
 
     @Getter
-    public class Tags {
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ToString
+    public static class Tags {
         private String name;
     }
 }

--- a/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
@@ -32,5 +32,10 @@ public class NovelsDto {
     private Genre genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
+    private List<Tags> tags;
 
+    @Getter
+    public class Tags {
+        private String name;
+    }
 }

--- a/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
@@ -31,5 +31,6 @@ public class ResponseNovelsDto {
     private Genre genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
+    private String tags;
 
 }

--- a/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
@@ -3,6 +3,7 @@ package com.readme.novels.novels.dto;
 import com.readme.novels.novels.model.Novels.Genre;
 import java.time.LocalDateTime;
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,7 +24,7 @@ public class ResponseNovelsDto {
     private String description;
     private String author;
     private Date startDate;
-    private String serializationDay;
+    private List<String> serializationDay;
     private String serializationStatus;
     private String thumbnail;
     private String authorComment;
@@ -31,6 +32,6 @@ public class ResponseNovelsDto {
     private Genre genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
-    private String tags;
+    private List<String> tags;
 
 }

--- a/src/main/java/com/readme/novels/novels/model/Novels.java
+++ b/src/main/java/com/readme/novels/novels/model/Novels.java
@@ -34,9 +34,11 @@ public class Novels extends BaseTimeEntity {
     private String thumbnail;
     private String authorComment;
     private Integer grade;
+    private String tags;
 
     @Enumerated(EnumType.STRING)
     private Genre genre;
+
 
     @Getter
     public enum Genre {

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
@@ -1,5 +1,6 @@
 package com.readme.novels.novels.requestObject;
 
+import com.readme.novels.novels.dto.NovelsDto.Tags;
 import com.readme.novels.novels.model.Novels.Genre;
 import java.util.Date;
 import java.util.List;
@@ -26,4 +27,5 @@ public class RequestAddNovels {
     private String authorComment;
     private Integer grade;
     private Genre genre;
+    private List<Tags> tags;
 }

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
@@ -1,5 +1,6 @@
 package com.readme.novels.novels.requestObject;
 
+import com.readme.novels.novels.dto.NovelsDto.Tags;
 import com.readme.novels.novels.model.Novels.Genre;
 import java.util.Date;
 import java.util.List;
@@ -27,4 +28,5 @@ public class RequestUpdateNovels {
     private String authorComment;
     private Integer grade;
     private Genre genre;
+    private List<Tags> tags;
 }

--- a/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
+++ b/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
@@ -2,6 +2,7 @@ package com.readme.novels.novels.responseObject;
 
 import com.readme.novels.novels.model.Novels.Genre;
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +21,7 @@ public class ResponseNovels {
     private String author;
     private String description;
     private Date startDate;
-    private String serializationDay;
+    private List<String> serializationDay;
     private String thumbnail;
     private String serializationStatus;
     private String authorComment;
@@ -28,5 +29,5 @@ public class ResponseNovels {
     private Genre genre;
     private Integer grade;
 
-    private String tags;
+    private List<String> tags;
 }

--- a/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
+++ b/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
@@ -27,4 +27,6 @@ public class ResponseNovels {
 
     private Genre genre;
     private Integer grade;
+
+    private String tags;
 }

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -1,6 +1,7 @@
 package com.readme.novels.novels.service;
 
 import com.readme.novels.novels.dto.NovelsDto;
+import com.readme.novels.novels.dto.NovelsDto.Tags;
 import com.readme.novels.novels.dto.PaginationDto;
 import com.readme.novels.novels.dto.ResponseNovelsDto;
 import com.readme.novels.novels.model.Novels;
@@ -33,8 +34,14 @@ public class NovelsServiceImpl implements NovelsService {
 
         List<String> serializationDays = novelsDto.getSerializationDay();
         StringBuffer serialization = new StringBuffer();
-            serializationDays.forEach(item -> {
-                serialization.append(item + ",");
+        serializationDays.forEach(item -> {
+            serialization.append(item + ",");
+        });
+
+        List<Tags> tags = novelsDto.getTags();
+        StringBuffer tagString = new StringBuffer();
+        tags.forEach(item -> {
+            tagString.append(item + ",");
         });
 
 
@@ -49,6 +56,7 @@ public class NovelsServiceImpl implements NovelsService {
             .startDate(novelsDto.getStartDate())
             .serializationStatus(novelsDto.getSerializationStatus())
             .description(novelsDto.getDescription())
+            .tags(tagString.toString().substring(0, tagString.length()-1))
             .build();
 
         iNovelsRepository.save(novels);

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -77,6 +77,12 @@ public class NovelsServiceImpl implements NovelsService {
             serialization.append(item + ",");
         });
 
+        List<Tags> tags = novelsDto.getTags();
+        StringBuffer tagString = new StringBuffer();
+        tags.forEach(item -> {
+            tagString.append(item + ",");
+        });
+
         Novels novels = Novels.builder()
             .id(novelsDto.getId())
             .genre(novelsDto.getGenre())
@@ -89,6 +95,7 @@ public class NovelsServiceImpl implements NovelsService {
             .thumbnail(novelsDto.getThumbnail())
             .authorComment(novelsDto.getAuthorComment())
             .description(novelsDto.getDescription())
+            .tags(tagString.toString().substring(0, tagString.length()-1))
             .build();
 
         iNovelsRepository.save(novels);
@@ -112,6 +119,7 @@ public class NovelsServiceImpl implements NovelsService {
             .serializationStatus("삭제")
             .startDate(novels.getStartDate())
             .thumbnail(novels.getThumbnail())
+            .tags(novels.getTags())
             .build();
     }
 

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -144,6 +144,7 @@ public class NovelsServiceImpl implements NovelsService {
             .thumbnail(novels.getThumbnail())
             .title(novels.getTitle())
             .startDate(novels.getStartDate())
+            .tags(novels.getTags())
             .build();
 
         return novelsDto;
@@ -169,6 +170,7 @@ public class NovelsServiceImpl implements NovelsService {
                 .genre(item.getGenre())
                 .grade(item.getGrade())
                 .authorComment(item.getAuthorComment())
+                .tags(item.getTags())
                 .build();
 
             novelsDtoList.add(novelsDto);

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -41,7 +41,7 @@ public class NovelsServiceImpl implements NovelsService {
         List<Tags> tags = novelsDto.getTags();
         StringBuffer tagString = new StringBuffer();
         tags.forEach(item -> {
-            tagString.append(item + ",");
+            tagString.append(item.getName() + ",");
         });
 
 
@@ -80,7 +80,7 @@ public class NovelsServiceImpl implements NovelsService {
         List<Tags> tags = novelsDto.getTags();
         StringBuffer tagString = new StringBuffer();
         tags.forEach(item -> {
-            tagString.append(item + ",");
+            tagString.append(item.getName() + ",");
         });
 
         Novels novels = Novels.builder()
@@ -121,6 +121,8 @@ public class NovelsServiceImpl implements NovelsService {
             .thumbnail(novels.getThumbnail())
             .tags(novels.getTags())
             .build();
+
+        iNovelsRepository.save(updateNovels);
     }
 
     @Override

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -9,6 +9,7 @@ import com.readme.novels.novels.repository.INovelsRepository;
 import com.readme.novels.novels.dto.NovelsSearchParamDto;
 import com.readme.novels.novels.repository.NovelsRepository;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -131,9 +132,11 @@ public class NovelsServiceImpl implements NovelsService {
             .orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 소설입니다."));
 
+        List<String> serializationDay = Arrays.asList(novels.getSerializationDay().split(","));
+        List<String> tags = Arrays.asList(novels.getTags().split(","));
         ResponseNovelsDto novelsDto = ResponseNovelsDto.builder()
             .id(novels.getId())
-            .serializationDay(novels.getSerializationDay())
+            .serializationDay(serializationDay)
             .serializationStatus(novels.getSerializationStatus())
             .grade(novels.getGrade())
             .genre(novels.getGenre())
@@ -146,7 +149,7 @@ public class NovelsServiceImpl implements NovelsService {
             .thumbnail(novels.getThumbnail())
             .title(novels.getTitle())
             .startDate(novels.getStartDate())
-            .tags(novels.getTags())
+            .tags(tags)
             .build();
 
         return novelsDto;
@@ -160,19 +163,21 @@ public class NovelsServiceImpl implements NovelsService {
         List<ResponseNovelsDto> novelsDtoList = new ArrayList<>();
 
         novelsList.forEach(item -> {
+            List<String> serializationDay = Arrays.asList(item.getSerializationDay().split(","));
+            List<String> tags = Arrays.asList(item.getTags().split(","));
             ResponseNovelsDto novelsDto = ResponseNovelsDto.builder()
                 .id(item.getId())
                 .title(item.getTitle())
                 .author(item.getAuthor())
                 .description(item.getDescription())
                 .startDate(item.getStartDate())
-                .serializationDay(item.getSerializationDay())
+                .serializationDay(serializationDay)
                 .serializationStatus(item.getSerializationStatus())
                 .thumbnail(item.getThumbnail())
                 .genre(item.getGenre())
                 .grade(item.getGrade())
                 .authorComment(item.getAuthorComment())
-                .tags(item.getTags())
+                .tags(tags)
                 .build();
 
             novelsDtoList.add(novelsDto);


### PR DESCRIPTION
1. 소설 CRUD 시 Tag 항목도 추가
 (기존 테이블 설계시에는 tag 테이블이 따로 있었는데 테이블 삭제)
2. 요일, 태그 데이터 프론트 요청에 따라 List 형태로 리턴하도록 수정