### PR TITLE
[UPDATE] #BTS-107 Novels genre 수정

### DIFF
--- a/src/main/java/com/readme/novels/category/repository/MainCategoryRepository.java
+++ b/src/main/java/com/readme/novels/category/repository/MainCategoryRepository.java
@@ -2,8 +2,11 @@ package com.readme.novels.category.repository;
 
 import com.readme.novels.category.model.MainCategory;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MainCategoryRepository extends JpaRepository<MainCategory, Long> {
     List<MainCategory> findAllByOrderById();
+
+    Optional<MainCategory> findByTitle(String genre);
 }

--- a/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/NovelsDto.java
@@ -1,6 +1,5 @@
 package com.readme.novels.novels.dto;
 
-import com.readme.novels.novels.model.Novels.Genre;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
@@ -29,7 +28,7 @@ public class NovelsDto {
     private String thumbnail;
     private String authorComment;
     private Integer grade;
-    private Genre genre;
+    private String genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
     private List<String> tags;

--- a/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
+++ b/src/main/java/com/readme/novels/novels/dto/ResponseNovelsDto.java
@@ -1,6 +1,5 @@
 package com.readme.novels.novels.dto;
 
-import com.readme.novels.novels.model.Novels.Genre;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
@@ -29,7 +28,7 @@ public class ResponseNovelsDto {
     private String thumbnail;
     private String authorComment;
     private Integer grade;
-    private Genre genre;
+    private String genre;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
     private List<String> tags;

--- a/src/main/java/com/readme/novels/novels/model/Novels.java
+++ b/src/main/java/com/readme/novels/novels/model/Novels.java
@@ -36,18 +36,18 @@ public class Novels extends BaseTimeEntity {
     private Integer grade;
     private String tags;
 
-    @Enumerated(EnumType.STRING)
-    private Genre genre;
+//    @Enumerated(EnumType.STRING)
+    private Long genre;
 
 
-    @Getter
-    public enum Genre {
-        판타지,
-        현판,
-        무협,
-        드라마,
-        로판,
-        로맨스;
-    }
+//    @Getter
+//    public enum Genre {
+//        판타지,
+//        현판,
+//        무협,
+//        드라마,
+//        로판,
+//        로맨스;
+//    }
 
 }

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestAddNovels.java
@@ -1,6 +1,5 @@
 package com.readme.novels.novels.requestObject;
 
-import com.readme.novels.novels.model.Novels.Genre;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -25,6 +24,6 @@ public class RequestAddNovels {
     private String thumbnail;
     private String authorComment;
     private Integer grade;
-    private Genre genre;
+    private String genre;
     private List<String> tags;
 }

--- a/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
+++ b/src/main/java/com/readme/novels/novels/requestObject/RequestUpdateNovels.java
@@ -1,6 +1,5 @@
 package com.readme.novels.novels.requestObject;
 
-import com.readme.novels.novels.model.Novels.Genre;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -26,6 +25,6 @@ public class RequestUpdateNovels {
     private String thumbnail;
     private String authorComment;
     private Integer grade;
-    private Genre genre;
+    private String genre;
     private List<String> tags;
 }

--- a/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
+++ b/src/main/java/com/readme/novels/novels/responseObject/ResponseNovels.java
@@ -1,6 +1,5 @@
 package com.readme.novels.novels.responseObject;
 
-import com.readme.novels.novels.model.Novels.Genre;
 import java.util.Date;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -26,7 +25,7 @@ public class ResponseNovels {
     private String serializationStatus;
     private String authorComment;
 
-    private Genre genre;
+    private String genre;
     private Integer grade;
 
     private List<String> tags;

--- a/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
+++ b/src/main/java/com/readme/novels/novels/service/NovelsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.readme.novels.novels.service;
 
+import com.readme.novels.category.model.MainCategory;
+import com.readme.novels.category.repository.MainCategoryRepository;
 import com.readme.novels.novels.dto.NovelsDto;
 import com.readme.novels.novels.dto.PaginationDto;
 import com.readme.novels.novels.dto.ResponseNovelsDto;
@@ -24,6 +26,7 @@ public class NovelsServiceImpl implements NovelsService {
 
     private final INovelsRepository iNovelsRepository;
     private final NovelsRepository novelsRepository;
+    private final MainCategoryRepository mainCategoryRepository;
 
     @Override
     public void addNovels(NovelsDto novelsDto) {
@@ -44,19 +47,23 @@ public class NovelsServiceImpl implements NovelsService {
             tagString.append(item + ",");
         });
 
+        MainCategory mainCategory = mainCategoryRepository.findByTitle(novelsDto.getGenre())
+            .orElseThrow(() -> {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리 입니다.");
+            });
 
         Novels novels = Novels.builder()
             .title(novelsDto.getTitle())
             .author(novelsDto.getAuthor())
             .grade(novelsDto.getGrade())
-            .genre(novelsDto.getGenre())
+            .genre(mainCategory.getId())
             .thumbnail(novelsDto.getThumbnail())
             .authorComment(novelsDto.getAuthorComment())
-            .serializationDay(serialization.toString().substring(0, serialization.length()-1))
+            .serializationDay(serialization.toString().substring(0, serialization.length() - 1))
             .startDate(novelsDto.getStartDate())
             .serializationStatus(novelsDto.getSerializationStatus())
             .description(novelsDto.getDescription())
-            .tags(tagString.toString().substring(0, tagString.length()-1))
+            .tags(tagString.toString().substring(0, tagString.length() - 1))
             .build();
 
         iNovelsRepository.save(novels);
@@ -83,19 +90,24 @@ public class NovelsServiceImpl implements NovelsService {
             tagString.append(item + ",");
         });
 
+        MainCategory mainCategory = mainCategoryRepository.findByTitle(novelsDto.getGenre())
+            .orElseThrow(() -> {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리 입니다.");
+            });
+
         Novels novels = Novels.builder()
             .id(novelsDto.getId())
-            .genre(novelsDto.getGenre())
+            .genre(mainCategory.getId())
             .grade(novelsDto.getGrade())
             .startDate(novelsDto.getStartDate())
             .serializationStatus(novelsDto.getSerializationStatus())
-            .serializationDay(serialization.toString().substring(0, serialization.length()-1))
+            .serializationDay(serialization.toString().substring(0, serialization.length() - 1))
             .title(novelsDto.getTitle())
             .author(novelsDto.getAuthor())
             .thumbnail(novelsDto.getThumbnail())
             .authorComment(novelsDto.getAuthorComment())
             .description(novelsDto.getDescription())
-            .tags(tagString.toString().substring(0, tagString.length()-1))
+            .tags(tagString.toString().substring(0, tagString.length() - 1))
             .build();
 
         iNovelsRepository.save(novels);
@@ -133,12 +145,16 @@ public class NovelsServiceImpl implements NovelsService {
 
         List<String> serializationDay = Arrays.asList(novels.getSerializationDay().split(","));
         List<String> tags = Arrays.asList(novels.getTags().split(","));
+        MainCategory mainCategory = mainCategoryRepository.findById(novels.getGenre())
+            .orElseThrow(() -> {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리 입니다.");
+            });
         ResponseNovelsDto novelsDto = ResponseNovelsDto.builder()
             .id(novels.getId())
             .serializationDay(serializationDay)
             .serializationStatus(novels.getSerializationStatus())
             .grade(novels.getGrade())
-            .genre(novels.getGenre())
+            .genre(mainCategory.getTitle())
             .author(novels.getAuthor())
             .authorComment(novels.getAuthorComment())
             .createDate(novels.getCreateDate())
@@ -164,6 +180,10 @@ public class NovelsServiceImpl implements NovelsService {
         novelsList.forEach(item -> {
             List<String> serializationDay = Arrays.asList(item.getSerializationDay().split(","));
             List<String> tags = Arrays.asList(item.getTags().split(","));
+            MainCategory mainCategory = mainCategoryRepository.findById(item.getGenre())
+                .orElseThrow(() -> {
+                    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리 입니다.");
+                });
             ResponseNovelsDto novelsDto = ResponseNovelsDto.builder()
                 .id(item.getId())
                 .title(item.getTitle())
@@ -173,7 +193,7 @@ public class NovelsServiceImpl implements NovelsService {
                 .serializationDay(serializationDay)
                 .serializationStatus(item.getSerializationStatus())
                 .thumbnail(item.getThumbnail())
-                .genre(item.getGenre())
+                .genre(mainCategory.getTitle())
                 .grade(item.getGrade())
                 .authorComment(item.getAuthorComment())
                 .tags(tags)
@@ -189,7 +209,6 @@ public class NovelsServiceImpl implements NovelsService {
     public PaginationDto getPagination(NovelsSearchParamDto novelsSearchParamDto) {
         return novelsRepository.getPagination(novelsSearchParamDto);
     }
-
 
 
 }


### PR DESCRIPTION
- genre enum 타입에서 mainCategory 테이블 id 저장 형태로 변경
- 프론트에서 요청할 때는 "String" ("판타지" 등) 저장할 때는 Long (mainCategoryId), 조회할 때는 "String"