### PR TITLE
[CREATE] #BTS-151 소설 읽은 내역 개발

### DIFF
--- a/src/main/java/com/readme/novels/NovelsApplication.java
+++ b/src/main/java/com/readme/novels/NovelsApplication.java
@@ -13,7 +13,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class NovelsApplication {
 
     public static void main(String[] args) {
+        setDefaultTimeZone();
         SpringApplication.run(NovelsApplication.class, args);
     }
 
+    private static void setDefaultTimeZone() {
+        java.util.TimeZone.setDefault(java.util.TimeZone.getTimeZone("Asia/Seoul"));
+    }
 }

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
@@ -1,0 +1,40 @@
+package com.readme.novels.episodes.controller;
+
+import com.readme.novels.commonResponseObject.CommonDataResponse;
+import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
+import com.readme.novels.episodes.responseObject.ResponseEpisodeHistory;
+import com.readme.novels.episodes.responseObject.ResponseEpisodeHistoryPagination;
+import com.readme.novels.episodes.service.EpisodeHistoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("v1/history")
+@Slf4j
+@RequiredArgsConstructor
+public class EpisodeHistoryController {
+
+    private final EpisodeHistoryService episodeHistoryService;
+
+    @GetMapping
+    public ResponseEntity<CommonDataResponse<ResponseEpisodeHistoryPagination>> getEpisodeHistoryByUser(
+        @RequestHeader("uuid") String uuid,
+        @PageableDefault(size = 12) Pageable pageable) {
+        EpisodeHistoryPaginationDto episodeHistoryPaginationDto
+            = episodeHistoryService.getEpisodeHistoryByUser(uuid, pageable);
+
+        return ResponseEntity.ok(new CommonDataResponse<>(
+            new ResponseEpisodeHistoryPagination(
+            episodeHistoryPaginationDto.getContents().stream().map(ResponseEpisodeHistory::new),
+            episodeHistoryPaginationDto.getPagination())
+        ));
+    }
+
+}

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
@@ -5,6 +5,7 @@ import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
 import com.readme.novels.episodes.responseObject.ResponseEpisodeHistory;
 import com.readme.novels.episodes.responseObject.ResponseEpisodeHistoryPagination;
 import com.readme.novels.episodes.service.EpisodeHistoryService;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -32,7 +33,8 @@ public class EpisodeHistoryController {
 
         return ResponseEntity.ok(new CommonDataResponse<>(
             new ResponseEpisodeHistoryPagination(
-            episodeHistoryPaginationDto.getContents().stream().map(ResponseEpisodeHistory::new),
+            episodeHistoryPaginationDto.getContents().stream().map(ResponseEpisodeHistory::new).collect(
+                Collectors.toList()),
             episodeHistoryPaginationDto.getPagination())
         ));
     }

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodesController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodesController.java
@@ -4,6 +4,7 @@ import com.readme.novels.episodes.dto.EpisodesDtoByUser;
 import com.readme.novels.episodes.dto.PlusViewsKafkaDto;
 import com.readme.novels.episodes.messagequeue.EpisodesKafkaProducer;
 import com.readme.novels.episodes.responseObject.ResponseEpisodesUser;
+import com.readme.novels.episodes.service.EpisodeHistoryService;
 import com.readme.novels.episodes.service.EpisodesService;
 import com.readme.novels.commonResponseObject.CommonDataResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,7 @@ public class EpisodesController {
 
     private final EpisodesService episodesService;
     private final EpisodesKafkaProducer episodesKafkaProducer;
+    private final EpisodeHistoryService episodeHistoryService;
 
     @Operation(summary = "에피소드 조회", description = "에피소드 조회, 조회할 에피소드 id url 전달", tags = {"에피소드"})
     @ApiResponses({
@@ -44,7 +46,7 @@ public class EpisodesController {
         episodesKafkaProducer.plusViewCount("plusViewCount", plusViewsKafkaDto);
 
         // 최근 읽은 목록에 추가
-        if (!uuid.equals("")) { episodesService.addEpisodeHistory(id, uuid); }
+        if (!uuid.equals("")) { episodeHistoryService.addEpisodeHistory(id, uuid); }
 
         return ResponseEntity.ok(
             new CommonDataResponse<>(

--- a/src/main/java/com/readme/novels/episodes/dto/EpisodeHistoryDto.java
+++ b/src/main/java/com/readme/novels/episodes/dto/EpisodeHistoryDto.java
@@ -1,0 +1,28 @@
+package com.readme.novels.episodes.dto;
+
+import com.readme.novels.episodes.model.EpisodeHistory;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class EpisodeHistoryDto {
+    private Long id;
+    private String uuid;
+    private Long novelId;
+    private Long episodeId;
+    private LocalDateTime createDate;
+
+    public EpisodeHistoryDto(EpisodeHistory episodeHistory) {
+        this.id = episodeHistory.getId();
+        this.uuid = episodeHistory.getUuid();
+        this.novelId = episodeHistory.getNovelId();
+        this.episodeId = episodeHistory.getEpisodeId();
+        this.createDate = episodeHistory.getCreateDate();
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/dto/EpisodeHistoryPaginationDto.java
+++ b/src/main/java/com/readme/novels/episodes/dto/EpisodeHistoryPaginationDto.java
@@ -1,0 +1,23 @@
+package com.readme.novels.episodes.dto;
+
+import com.readme.novels.episodes.model.EpisodeHistory;
+import com.readme.novels.episodes.responseObject.ResponseEpisodesPagination.Pagination;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class EpisodeHistoryPaginationDto {
+    private List<EpisodeHistoryDto> contents;
+    private Pagination pagination;
+
+    public EpisodeHistoryPaginationDto(List<EpisodeHistoryDto> contents, Pagination pagination) {
+        this.contents = contents;
+        this.pagination = pagination;
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/model/EpisodeHistory.java
+++ b/src/main/java/com/readme/novels/episodes/model/EpisodeHistory.java
@@ -1,0 +1,36 @@
+package com.readme.novels.episodes.model;
+
+import com.readme.novels.utils.BaseTimeEntity;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Entity
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class EpisodeHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String uuid;
+    private Long novelId;
+    private Long episodeId;
+    // private Long readAt; 읽은 위치? 페이지? 줄수? 나중에 추가
+
+
+    public EpisodeHistory(String uuid, Long novelId, Long episodeId) {
+        this.uuid = uuid;
+        this.novelId = novelId;
+        this.episodeId = episodeId;
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
@@ -2,9 +2,13 @@ package com.readme.novels.episodes.repository;
 
 import com.readme.novels.episodes.model.EpisodeHistory;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, Long> {
     Optional<EpisodeHistory> findByUuidAndNovelId(String uuid, long novelId);
+
+    Page<EpisodeHistory> findByUuidOrderByUpdateDateDesc(String uuid, Pageable pageable);
 
 }

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.readme.novels.episodes.repository;
+
+import com.readme.novels.episodes.model.EpisodeHistory;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, Long> {
+    Optional<EpisodeHistory> findByUuidAndNovelId(String uuid, long novelId);
+
+}

--- a/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodeHistory.java
+++ b/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodeHistory.java
@@ -1,0 +1,26 @@
+package com.readme.novels.episodes.responseObject;
+
+import com.readme.novels.episodes.dto.EpisodeHistoryDto;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class ResponseEpisodeHistory {
+    private Long id;
+    private String uuid;
+    private Long novelId;
+    private Long episodeId;
+    private LocalDateTime createDate;
+
+    public ResponseEpisodeHistory(EpisodeHistoryDto episodeHistoryDto) {
+        this.id = episodeHistoryDto.getId();
+        this.uuid = episodeHistoryDto.getUuid();
+        this.novelId = episodeHistoryDto.getNovelId();
+        this.episodeId = episodeHistoryDto.getEpisodeId();
+        this.createDate = episodeHistoryDto.getCreateDate();
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodeHistoryPagination.java
+++ b/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodeHistoryPagination.java
@@ -1,6 +1,7 @@
 package com.readme.novels.episodes.responseObject;
 
 import com.readme.novels.episodes.responseObject.ResponseEpisodesPagination.Pagination;
+import java.util.List;
 import java.util.stream.Stream;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,10 +11,10 @@ import lombok.ToString;
 @NoArgsConstructor
 @ToString
 public class ResponseEpisodeHistoryPagination {
-    private Stream<ResponseEpisodeHistory> contents;
+    private List<ResponseEpisodeHistory> contents;
     private Pagination pagination;
 
-    public ResponseEpisodeHistoryPagination(Stream<ResponseEpisodeHistory> contents,
+    public ResponseEpisodeHistoryPagination(List<ResponseEpisodeHistory> contents,
         Pagination pagination) {
         this.contents = contents;
         this.pagination = pagination;

--- a/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodeHistoryPagination.java
+++ b/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodeHistoryPagination.java
@@ -1,0 +1,21 @@
+package com.readme.novels.episodes.responseObject;
+
+import com.readme.novels.episodes.responseObject.ResponseEpisodesPagination.Pagination;
+import java.util.stream.Stream;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@ToString
+public class ResponseEpisodeHistoryPagination {
+    private Stream<ResponseEpisodeHistory> contents;
+    private Pagination pagination;
+
+    public ResponseEpisodeHistoryPagination(Stream<ResponseEpisodeHistory> contents,
+        Pagination pagination) {
+        this.contents = contents;
+        this.pagination = pagination;
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
@@ -1,6 +1,11 @@
 package com.readme.novels.episodes.service;
 
+import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
+import org.springframework.data.domain.Pageable;
+
 public interface EpisodeHistoryService {
 
     void addEpisodeHistory(Long id, String uuid);
+
+    EpisodeHistoryPaginationDto getEpisodeHistoryByUser(String uuid, Pageable pageable);
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
@@ -1,0 +1,6 @@
+package com.readme.novels.episodes.service;
+
+public interface EpisodeHistoryService {
+
+    void addEpisodeHistory(Long id, String uuid);
+}

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -1,0 +1,36 @@
+package com.readme.novels.episodes.service;
+
+import com.readme.novels.episodes.model.EpisodeHistory;
+import com.readme.novels.episodes.model.Episodes;
+import com.readme.novels.episodes.repository.EpisodeHistoryRepository;
+import com.readme.novels.episodes.repository.EpisodesRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+@RequiredArgsConstructor
+public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
+
+    private final EpisodeHistoryRepository episodeHistoryRepository;
+    private final EpisodesRepository episodesRepository;
+
+    @Override
+    public void addEpisodeHistory(Long id, String uuid) {
+        Episodes episodes = episodesRepository.findById(id).orElseThrow(() -> {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        });
+
+        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndNovelId(uuid, episodes.getNovelsId());
+
+        if (episodeHistory.isEmpty()) {
+            EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(), episodes.getId());
+            episodeHistoryRepository.save(newEpisodeHistory);
+        } else {
+            episodeHistory.get().setEpisodeId(episodes.getId());
+            episodeHistoryRepository.save(episodeHistory.get());
+        }
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -1,11 +1,18 @@
 package com.readme.novels.episodes.service;
 
+import com.readme.novels.episodes.dto.EpisodeHistoryDto;
+import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
 import com.readme.novels.episodes.model.EpisodeHistory;
 import com.readme.novels.episodes.model.Episodes;
 import com.readme.novels.episodes.repository.EpisodeHistoryRepository;
 import com.readme.novels.episodes.repository.EpisodesRepository;
+import com.readme.novels.episodes.responseObject.ResponseEpisodesPagination.Pagination;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -23,14 +30,41 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         });
 
-        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndNovelId(uuid, episodes.getNovelsId());
+        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndNovelId(
+            uuid, episodes.getNovelsId());
 
         if (episodeHistory.isEmpty()) {
-            EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(), episodes.getId());
+            EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(),
+                episodes.getId());
             episodeHistoryRepository.save(newEpisodeHistory);
         } else {
             episodeHistory.get().setEpisodeId(episodes.getId());
             episodeHistoryRepository.save(episodeHistory.get());
         }
+    }
+
+    @Override
+    public EpisodeHistoryPaginationDto getEpisodeHistoryByUser(String uuid, Pageable pageable) {
+        Page<EpisodeHistory> episodeHistoryPage = episodeHistoryRepository
+            .findByUuidOrderByUpdateDateDesc(uuid, pageable);
+
+        List<EpisodeHistoryDto> episodeHistoryDtoList = new ArrayList<>();
+
+        episodeHistoryPage.forEach(episodeHistory -> {
+            EpisodeHistoryDto episodeHistoryDto = new EpisodeHistoryDto(episodeHistory);
+            episodeHistoryDtoList.add(episodeHistoryDto);
+        });
+
+        Pagination pagination = Pagination.builder()
+            .page(episodeHistoryPage.getNumber())
+            .size(episodeHistoryPage.getSize())
+            .totalElements(episodeHistoryPage.getTotalElements())
+            .totalPage(episodeHistoryPage.getTotalPages())
+            .build();
+
+        EpisodeHistoryPaginationDto episodeHistoryPaginationDto = new EpisodeHistoryPaginationDto(
+            episodeHistoryDtoList, pagination);
+
+        return episodeHistoryPaginationDto;
     }
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodesService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodesService.java
@@ -20,5 +20,4 @@ public interface EpisodesService {
 
     void plusViewsCount(Long id, Integer plusCount);
 
-    void addEpisodeHistory(Long id, String uuid);
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodesService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodesService.java
@@ -19,4 +19,6 @@ public interface EpisodesService {
     EpisodesDtoByUser getEpisodesByUser(Long id);
 
     void plusViewsCount(Long id, Integer plusCount);
+
+    void addEpisodeHistory(Long id, String uuid);
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodesServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodesServiceImpl.java
@@ -178,21 +178,4 @@ public class EpisodesServiceImpl implements EpisodesService {
 
     }
 
-    @Override
-    public void addEpisodeHistory(Long id, String uuid) {
-        Episodes episodes = episodesRepository.findById(id).orElseThrow(() -> {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
-        });
-
-        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndNovelId(uuid, episodes.getNovelsId());
-
-        if (episodeHistory.isEmpty()) {
-            EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(), episodes.getId());
-            episodeHistoryRepository.save(newEpisodeHistory);
-        } else {
-            episodeHistory.get().setEpisodeId(episodes.getId());
-            episodeHistoryRepository.save(episodeHistory.get());
-        }
-
-    }
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodesServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodesServiceImpl.java
@@ -3,7 +3,9 @@ package com.readme.novels.episodes.service;
 import com.readme.novels.episodes.dto.EpisodesDto;
 import com.readme.novels.episodes.dto.EpisodesDtoByUser;
 import com.readme.novels.episodes.dto.EpisodesPageDto;
+import com.readme.novels.episodes.model.EpisodeHistory;
 import com.readme.novels.episodes.model.Episodes;
+import com.readme.novels.episodes.repository.EpisodeHistoryRepository;
 import com.readme.novels.episodes.repository.EpisodesRepository;
 import com.readme.novels.episodes.responseObject.ResponseEpisodesPagination.Pagination;
 import com.readme.novels.novels.model.Novels;
@@ -11,6 +13,7 @@ import com.readme.novels.novels.repository.INovelsRepository;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -26,6 +29,7 @@ public class EpisodesServiceImpl implements EpisodesService {
 
     private final EpisodesRepository episodesRepository;
     private final INovelsRepository iNovelsRepository;
+    private final EpisodeHistoryRepository episodeHistoryRepository;
 
     @Override
     public void addEpisodes(EpisodesDto episodesDto) {
@@ -130,7 +134,7 @@ public class EpisodesServiceImpl implements EpisodesService {
             episodesDtoList.add(episodesDto);
         });
 
-        EpisodesPageDto episodesPageDto = new EpisodesPageDto(episodesDtoList, pagination) ;
+        EpisodesPageDto episodesPageDto = new EpisodesPageDto(episodesDtoList, pagination);
 
         return episodesPageDto;
     }
@@ -141,10 +145,11 @@ public class EpisodesServiceImpl implements EpisodesService {
         Episodes episodes = episodesRepository.findById(id).orElseThrow(() -> {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "존재하지 않는 에피소드 입니다.");
         });
-        
+
         EpisodesDtoByUser episodesDtoByUser = new EpisodesDtoByUser(episodes);
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        episodesDtoByUser.setModifiedRegistration(episodes.getRegistration().format(dateTimeFormatter));
+        episodesDtoByUser.setModifiedRegistration(
+            episodes.getRegistration().format(dateTimeFormatter));
 
         Novels novels = iNovelsRepository.findById(episodes.getNovelsId()).get();
         episodesDtoByUser.setNovelsTitle(novels.getTitle());
@@ -160,7 +165,7 @@ public class EpisodesServiceImpl implements EpisodesService {
 
         Episodes updateEpisodes = Episodes.builder()
             .title(episodes.getTitle())
-            .views(episodes.getViews()+plusCount)
+            .views(episodes.getViews() + plusCount)
             .content(episodes.getContent())
             .registration(episodes.getRegistration())
             .free(episodes.isFree())
@@ -170,6 +175,24 @@ public class EpisodesServiceImpl implements EpisodesService {
             .build();
 
         episodesRepository.save(updateEpisodes);
+
+    }
+
+    @Override
+    public void addEpisodeHistory(Long id, String uuid) {
+        Episodes episodes = episodesRepository.findById(id).orElseThrow(() -> {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        });
+
+        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndNovelId(uuid, episodes.getNovelsId());
+
+        if (episodeHistory.isEmpty()) {
+            EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(), episodes.getId());
+            episodeHistoryRepository.save(newEpisodeHistory);
+        } else {
+            episodeHistory.get().setEpisodeId(episodes.getId());
+            episodeHistoryRepository.save(episodeHistory.get());
+        }
 
     }
 }


### PR DESCRIPTION
1. 소설 읽은 내역 추가 기능
  - 소설 읽으면 자동으로 내역 추가 메서드 실행
  - 현재 어디까지 읽었는지는 미구현, 프론트에서 넘겨주는 방식에 따라 바뀌어야 할 것 같습니다.
2. 소설 읽은 내역 조회
  - 최근 순(updateDate) 순으로 정렬
  - 소설별로 가장 최근에 읽은 회차만 저장
3. defaultTimeZone 서울로 세팅