### PR TITLE
Bts 169/function

### DIFF
--- a/src/main/java/com/readme/novels/episodes/controller/AdminEpisodesController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/AdminEpisodesController.java
@@ -9,6 +9,7 @@ import com.readme.novels.episodes.requestObject.RequestAddEpisodes;
 import com.readme.novels.episodes.requestObject.RequestUpdateEpisodes;
 import com.readme.novels.episodes.responseObject.ResponseEpisodes;
 import com.readme.novels.episodes.responseObject.ResponseEpisodesPagination;
+import com.readme.novels.episodes.service.EpisodeHistoryService;
 import com.readme.novels.episodes.service.EpisodesService;
 import com.readme.novels.commonResponseObject.CommonDataResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,6 +38,7 @@ public class AdminEpisodesController {
 
     private final EpisodesService episodesService;
     private final EpisodesKafkaProducer episodesKafkaProducer;
+    private final EpisodeHistoryService episodeHistoryService;
 
     @Operation(summary = "에피소드 추가", description = "에피소드 추가", tags = {"Admin 에피소드"})
     @ApiResponses({
@@ -87,6 +89,8 @@ public class AdminEpisodesController {
         long novelId = episodesService.deleteEpisodes(id);
 
         episodesKafkaProducer.deleteEpisodes("deleteEpisodes", new EpisodesDeleteKafkaDto(id, novelId));
+
+        episodeHistoryService.deleteEpisodeById(id);
     }
 
     @Operation(summary = "에피소드 단건 조회", description = "에피소드 단건 조회, 조회할 에피소드 id url 전달", tags = {

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
@@ -1,6 +1,7 @@
 package com.readme.novels.episodes.controller;
 
 import com.readme.novels.commonResponseObject.CommonDataResponse;
+import com.readme.novels.episodes.dto.EpisodeHistoryDto;
 import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
 import com.readme.novels.episodes.dto.UpdateReadAtDto;
 import com.readme.novels.episodes.requestObject.RequestUpdateReadAt;
@@ -10,7 +11,10 @@ import com.readme.novels.episodes.service.EpisodeHistoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.Fetch;
@@ -50,9 +54,10 @@ public class EpisodeHistoryController {
 
         return ResponseEntity.ok(new CommonDataResponse<>(
             new ResponseEpisodeHistoryPagination(
-            episodeHistoryPaginationDto.getContents().stream().map(ResponseEpisodeHistory::new).collect(
-                Collectors.toList()),
-            episodeHistoryPaginationDto.getPagination())
+                episodeHistoryPaginationDto.getContents().stream().map(ResponseEpisodeHistory::new)
+                    .collect(
+                        Collectors.toList()),
+                episodeHistoryPaginationDto.getPagination())
         ));
     }
 
@@ -64,7 +69,8 @@ public class EpisodeHistoryController {
         @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
     })
     @DeleteMapping("/{historyId}")
-    public void deleteEpisodeHistoryByUser(@RequestHeader("uuid") String uuid, @PathVariable Long historyId) {
+    public void deleteEpisodeHistoryByUser(@RequestHeader("uuid") String uuid,
+        @PathVariable Long historyId) {
         episodeHistoryService.deleteEpisodeHistoryByUser(uuid, historyId);
 
     }
@@ -73,6 +79,20 @@ public class EpisodeHistoryController {
     public void updateHistoryReadAt(@RequestHeader("uuid") String uuid,
         @RequestBody RequestUpdateReadAt requestUpdateReadAt) {
         episodeHistoryService.updateEpisodeReadAt(new UpdateReadAtDto(uuid, requestUpdateReadAt));
+    }
+
+    @GetMapping("/novel/{novelId}")
+    public ResponseEntity<CommonDataResponse<List<ResponseEpisodeHistory>>> getReadEpisodeByNovelId(
+        @RequestHeader(value = "uuid") String uuid, @PathVariable Long novelId) {
+        List<EpisodeHistoryDto> episodeHistoryDtoList
+            = episodeHistoryService.getReadEpisodeByNovelId(uuid, novelId);
+
+        List<ResponseEpisodeHistory> responseEpisodeHistoryList = new ArrayList<>();
+        episodeHistoryDtoList.forEach(episodeHistoryDto -> {
+            responseEpisodeHistoryList.add(new ResponseEpisodeHistory(episodeHistoryDto));
+        });
+
+        return ResponseEntity.ok(new CommonDataResponse<>(responseEpisodeHistoryList));
     }
 
 }

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodeHistoryController.java
@@ -75,12 +75,26 @@ public class EpisodeHistoryController {
 
     }
 
+    @Operation(summary = "읽은 페이지 저장", description = "어디까지 읽었는지 읽은 페이지 저장", tags = {"읽은 내역"})
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+        @ApiResponse(responseCode = "404", description = "NOT FOUND"),
+        @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+    })
     @PatchMapping
     public void updateHistoryReadAt(@RequestHeader("uuid") String uuid,
         @RequestBody RequestUpdateReadAt requestUpdateReadAt) {
         episodeHistoryService.updateEpisodeReadAt(new UpdateReadAtDto(uuid, requestUpdateReadAt));
     }
 
+    @Operation(summary = "소설 별 읽은 에피소드 조회", description = "소설별로 유저가 읽은 에피소드 조회", tags = {"읽은 내역"})
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "BAD REQUEST"),
+        @ApiResponse(responseCode = "404", description = "NOT FOUND"),
+        @ApiResponse(responseCode = "500", description = "INTERNAL SERVER ERROR")
+    })
     @GetMapping("/novel/{novelId}")
     public ResponseEntity<CommonDataResponse<List<ResponseEpisodeHistory>>> getReadEpisodeByNovelId(
         @RequestHeader(value = "uuid") String uuid, @PathVariable Long novelId) {

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodesController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodesController.java
@@ -44,8 +44,8 @@ public class EpisodesController {
         EpisodesDtoByUser episodesDtoByUser = episodesService.getEpisodesByUser(uuid, id);
 
         // 조회수 증가 topic 전송
-//        PlusViewsKafkaDto plusViewsKafkaDto = new PlusViewsKafkaDto(episodesDtoByUser);
-//        episodesKafkaProducer.plusViewCount("plusViewCount", plusViewsKafkaDto);
+        PlusViewsKafkaDto plusViewsKafkaDto = new PlusViewsKafkaDto(episodesDtoByUser);
+        episodesKafkaProducer.plusViewCount("plusViewCount", plusViewsKafkaDto);
 
         // 최근 읽은 목록에 추가
         if (!uuid.equals("")) { episodeHistoryService.addEpisodeHistory(id, uuid); }

--- a/src/main/java/com/readme/novels/episodes/controller/EpisodesController.java
+++ b/src/main/java/com/readme/novels/episodes/controller/EpisodesController.java
@@ -41,11 +41,11 @@ public class EpisodesController {
         @PathVariable Long id,
         @RequestHeader(value = "uuid", required = false, defaultValue = "") String uuid) {
 
-        EpisodesDtoByUser episodesDtoByUser = episodesService.getEpisodesByUser(id);
+        EpisodesDtoByUser episodesDtoByUser = episodesService.getEpisodesByUser(uuid, id);
 
         // 조회수 증가 topic 전송
-        PlusViewsKafkaDto plusViewsKafkaDto = new PlusViewsKafkaDto(episodesDtoByUser);
-        episodesKafkaProducer.plusViewCount("plusViewCount", plusViewsKafkaDto);
+//        PlusViewsKafkaDto plusViewsKafkaDto = new PlusViewsKafkaDto(episodesDtoByUser);
+//        episodesKafkaProducer.plusViewCount("plusViewCount", plusViewsKafkaDto);
 
         // 최근 읽은 목록에 추가
         if (!uuid.equals("")) { episodeHistoryService.addEpisodeHistory(id, uuid); }

--- a/src/main/java/com/readme/novels/episodes/dto/EpisodeRecentHistoryDto.java
+++ b/src/main/java/com/readme/novels/episodes/dto/EpisodeRecentHistoryDto.java
@@ -1,0 +1,21 @@
+package com.readme.novels.episodes.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor
+@Setter
+@ToString
+public class EpisodeRecentHistoryDto {
+    private long novelId;
+    private long episodeId;
+    private long readAt;
+
+    public EpisodeRecentHistoryDto(long novelId, long episodeId) {
+        this.novelId = novelId;
+        this.episodeId = episodeId;
+    }
+}

--- a/src/main/java/com/readme/novels/episodes/dto/EpisodesDtoByUser.java
+++ b/src/main/java/com/readme/novels/episodes/dto/EpisodesDtoByUser.java
@@ -22,6 +22,13 @@ public class EpisodesDtoByUser {
     private LocalDateTime updateDate;
     private String status;
 
+    private long prevId;
+    private boolean prevFree;
+    private boolean prevRead;
+    private long nextId;
+    private boolean nextFree;
+    private boolean nextRead;
+
     public EpisodesDtoByUser(Episodes episodes) {
         this.id = episodes.getId();
         this.novelsId = episodes.getNovelsId();

--- a/src/main/java/com/readme/novels/episodes/model/EpisodeHistory.java
+++ b/src/main/java/com/readme/novels/episodes/model/EpisodeHistory.java
@@ -26,11 +26,13 @@ public class EpisodeHistory extends BaseTimeEntity {
     private Long novelId;
     private Long episodeId;
     private Long readAt;
+    private Boolean free;
 
 
-    public EpisodeHistory(String uuid, Long novelId, Long episodeId) {
+    public EpisodeHistory(String uuid, Long novelId, Long episodeId, boolean free) {
         this.uuid = uuid;
         this.novelId = novelId;
         this.episodeId = episodeId;
+        this.free = free;
     }
 }

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
@@ -26,4 +26,8 @@ public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, 
     Page<EpisodeRecentHistoryDto> findRecentEpisodeIdsByUuid(@Param("uuid") String uuid, Pageable pageable);
 
     Boolean existsByUuidAndEpisodeId(String uuid, Long episode);
+
+    void deleteByEpisodeId(Long id);
+
+    void deleteByNovelId(long id);
 }

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
@@ -1,10 +1,14 @@
 package com.readme.novels.episodes.repository;
 
+import com.readme.novels.episodes.dto.EpisodeRecentHistoryDto;
 import com.readme.novels.episodes.model.EpisodeHistory;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, Long> {
     Optional<EpisodeHistory> findByUuidAndNovelId(String uuid, long novelId);
@@ -14,4 +18,10 @@ public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, 
     Boolean existsByIdAndUuid(Long id, String uuid);
 
     Optional<EpisodeHistory> findByUuidAndEpisodeId(String uuid, long episodeId);
+
+    @Query("SELECT new com.readme.novels.episodes.dto.EpisodeRecentHistoryDto(e.novelId, MAX(e.episodeId)) " +
+        "FROM EpisodeHistory e " +
+        "WHERE e.uuid = :uuid " +
+        "GROUP BY e.novelId")
+    Page<EpisodeRecentHistoryDto> findRecentEpisodeIdsByUuid(@Param("uuid") String uuid, Pageable pageable);
 }

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, Long> {
-    Optional<EpisodeHistory> findByUuidAndNovelId(String uuid, long novelId);
+    List<EpisodeHistory> findByUuidAndNovelId(String uuid, long novelId);
 
     Page<EpisodeHistory> findByUuidOrderByUpdateDateDesc(String uuid, Pageable pageable);
 

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodeHistoryRepository.java
@@ -24,4 +24,6 @@ public interface EpisodeHistoryRepository extends JpaRepository<EpisodeHistory, 
         "WHERE e.uuid = :uuid " +
         "GROUP BY e.novelId")
     Page<EpisodeRecentHistoryDto> findRecentEpisodeIdsByUuid(@Param("uuid") String uuid, Pageable pageable);
+
+    Boolean existsByUuidAndEpisodeId(String uuid, Long episode);
 }

--- a/src/main/java/com/readme/novels/episodes/repository/EpisodesRepository.java
+++ b/src/main/java/com/readme/novels/episodes/repository/EpisodesRepository.java
@@ -2,10 +2,15 @@ package com.readme.novels.episodes.repository;
 
 import com.readme.novels.episodes.model.Episodes;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EpisodesRepository extends JpaRepository<Episodes, Long> {
     public Page<Episodes> findByNovelsIdOrderByCreateDateDesc(Long novelsId, Pageable pageable);
+
+    Optional<Episodes> findFirstByNovelsIdAndIdGreaterThanOrderByIdAsc(Long novelId, Long id);
+
+    Optional<Episodes> findFirstByNovelsIdAndIdLessThanOrderByIdDesc(Long novelId, Long id);
 }

--- a/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodesUser.java
+++ b/src/main/java/com/readme/novels/episodes/responseObject/ResponseEpisodesUser.java
@@ -16,6 +16,13 @@ public class ResponseEpisodesUser {
     private String content;
     private String registration;
 
+    private long prevId;
+    private boolean prevFree;
+    private boolean prevRead;
+    private long nextId;
+    private boolean nextFree;
+    private boolean nextRead;
+
     public ResponseEpisodesUser(EpisodesDtoByUser episodesDtoByUser) {
         this.id = episodesDtoByUser.getId();
         this.novelId = episodesDtoByUser.getNovelsId();
@@ -23,5 +30,11 @@ public class ResponseEpisodesUser {
         this.title = episodesDtoByUser.getTitle();
         this.content = episodesDtoByUser.getContent();
         this.registration = episodesDtoByUser.getRegistration();
+        this.prevId = episodesDtoByUser.getPrevId();
+        this.prevFree = episodesDtoByUser.isPrevFree();
+        this.prevRead = episodesDtoByUser.isPrevRead();
+        this.nextId = episodesDtoByUser.getNextId();
+        this.nextFree = episodesDtoByUser.isNextFree();
+        this.nextRead = episodesDtoByUser.isNextRead();
     }
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
@@ -20,4 +20,6 @@ public interface EpisodeHistoryService {
     List<EpisodeHistoryDto> getReadEpisodeByNovelId(String uuid, Long novelId);
 
     void deleteEpisodeById(Long id);
+
+    void deleteEpisodeByNovelsId(long id);
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
@@ -1,7 +1,10 @@
 package com.readme.novels.episodes.service;
 
+import com.readme.novels.episodes.dto.EpisodeHistoryDto;
 import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
 import com.readme.novels.episodes.dto.UpdateReadAtDto;
+import com.readme.novels.episodes.model.EpisodeHistory;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface EpisodeHistoryService {
@@ -13,4 +16,6 @@ public interface EpisodeHistoryService {
     void deleteEpisodeHistoryByUser(String uuid, Long historyId);
 
     void updateEpisodeReadAt(UpdateReadAtDto updateReadAtDto);
+
+    List<EpisodeHistoryDto> getReadEpisodeByNovelId(String uuid, Long novelId);
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryService.java
@@ -18,4 +18,6 @@ public interface EpisodeHistoryService {
     void updateEpisodeReadAt(UpdateReadAtDto updateReadAtDto);
 
     List<EpisodeHistoryDto> getReadEpisodeByNovelId(String uuid, Long novelId);
+
+    void deleteEpisodeById(Long id);
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -41,7 +41,7 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
 
         if (episodeHistory.isEmpty()) {
             EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(),
-                episodes.getId());
+                episodes.getId(), episodes.isFree());
             episodeHistoryRepository.save(newEpisodeHistory);
         }
     }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -114,6 +114,12 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
     @Transactional
     @Override
     public void deleteEpisodeById(Long id) {
-        episodeHistoryRepository.deleteById(id);
+        episodeHistoryRepository.deleteByEpisodeId(id);
+    }
+
+    @Transactional
+    @Override
+    public void deleteEpisodeByNovelsId(long id) {
+        episodeHistoryRepository.deleteByNovelId(id);
     }
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -110,4 +110,10 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
 
         return episodeHistoryDtoList;
     }
+
+    @Transactional
+    @Override
+    public void deleteEpisodeById(Long id) {
+        episodeHistoryRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -94,4 +94,20 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
         episodeHistory.setReadAt(updateReadAtDto.getReadAt());
         episodeHistoryRepository.save(episodeHistory);
     }
+
+    @Override
+    public List<EpisodeHistoryDto> getReadEpisodeByNovelId(String uuid, Long novelId) {
+
+        List<EpisodeHistory> episodeHistoryList
+            = episodeHistoryRepository.findByUuidAndNovelId(uuid, novelId);
+
+        List<EpisodeHistoryDto> episodeHistoryDtoList = new ArrayList<>();
+
+        episodeHistoryList.forEach(episodeHistory -> {
+            EpisodeHistoryDto episodeHistoryDto = new EpisodeHistoryDto(episodeHistory);
+            episodeHistoryDtoList.add(episodeHistoryDto);
+        });
+
+        return episodeHistoryDtoList;
+    }
 }

--- a/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodeHistoryServiceImpl.java
@@ -2,6 +2,7 @@ package com.readme.novels.episodes.service;
 
 import com.readme.novels.episodes.dto.EpisodeHistoryDto;
 import com.readme.novels.episodes.dto.EpisodeHistoryPaginationDto;
+import com.readme.novels.episodes.dto.EpisodeRecentHistoryDto;
 import com.readme.novels.episodes.dto.UpdateReadAtDto;
 import com.readme.novels.episodes.model.EpisodeHistory;
 import com.readme.novels.episodes.model.Episodes;
@@ -12,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -21,6 +23,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
 
     private final EpisodeHistoryRepository episodeHistoryRepository;
@@ -32,27 +35,30 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         });
 
-        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndNovelId(
-            uuid, episodes.getNovelsId());
+        // uuid랑 episode id로 조회
+        Optional<EpisodeHistory> episodeHistory = episodeHistoryRepository.findByUuidAndEpisodeId(
+            uuid, episodes.getId());
 
         if (episodeHistory.isEmpty()) {
             EpisodeHistory newEpisodeHistory = new EpisodeHistory(uuid, episodes.getNovelsId(),
                 episodes.getId());
             episodeHistoryRepository.save(newEpisodeHistory);
-        } else {
-            episodeHistory.get().setEpisodeId(episodes.getId());
-            episodeHistoryRepository.save(episodeHistory.get());
         }
     }
 
     @Override
     public EpisodeHistoryPaginationDto getEpisodeHistoryByUser(String uuid, Pageable pageable) {
-        Page<EpisodeHistory> episodeHistoryPage = episodeHistoryRepository
-            .findByUuidOrderByUpdateDateDesc(uuid, pageable);
+//        Page<EpisodeHistory> episodeHistoryPage = episodeHistoryRepository
+//            .findByUuidOrderByUpdateDateDesc(uuid, pageable);
 
+        Page<EpisodeRecentHistoryDto> episodeHistoryPage = episodeHistoryRepository
+            .findRecentEpisodeIdsByUuid(uuid, pageable);
         List<EpisodeHistoryDto> episodeHistoryDtoList = new ArrayList<>();
 
-        episodeHistoryPage.forEach(episodeHistory -> {
+        episodeHistoryPage.forEach(dto -> {
+            EpisodeHistory episodeHistory = episodeHistoryRepository
+                .findByUuidAndEpisodeId(uuid, dto.getEpisodeId()).get();
+
             EpisodeHistoryDto episodeHistoryDto = new EpisodeHistoryDto(episodeHistory);
             episodeHistoryDtoList.add(episodeHistoryDto);
         });
@@ -64,10 +70,7 @@ public class EpisodeHistoryServiceImpl implements EpisodeHistoryService {
             .totalPage(episodeHistoryPage.getTotalPages())
             .build();
 
-        EpisodeHistoryPaginationDto episodeHistoryPaginationDto = new EpisodeHistoryPaginationDto(
-            episodeHistoryDtoList, pagination);
-
-        return episodeHistoryPaginationDto;
+        return new EpisodeHistoryPaginationDto(episodeHistoryDtoList, pagination);
     }
 
     @Transactional

--- a/src/main/java/com/readme/novels/episodes/service/EpisodesService.java
+++ b/src/main/java/com/readme/novels/episodes/service/EpisodesService.java
@@ -16,7 +16,7 @@ public interface EpisodesService {
 
     EpisodesPageDto getEpisodesByNovelsId(Long novelId, Pageable pageable);
 
-    EpisodesDtoByUser getEpisodesByUser(Long id);
+    EpisodesDtoByUser getEpisodesByUser(String uuid, Long id);
 
     void plusViewsCount(Long id, Integer plusCount);
 

--- a/src/main/java/com/readme/novels/novels/controller/AdminNovelsController.java
+++ b/src/main/java/com/readme/novels/novels/controller/AdminNovelsController.java
@@ -1,5 +1,6 @@
 package com.readme.novels.novels.controller;
 
+import com.readme.novels.episodes.service.EpisodeHistoryService;
 import com.readme.novels.novels.dto.NovelsDeleteKafkaDto;
 import com.readme.novels.novels.dto.NovelsDto;
 import com.readme.novels.novels.dto.NovelsKafkaDto;
@@ -39,6 +40,7 @@ public class AdminNovelsController {
 
     private final NovelsService novelsService;
     private final NovelsKafkaProducer novelsKafkaProducer;
+    private final EpisodeHistoryService episodeHistoryService;
 
     @Operation(summary = "소설 추가", description = "소설 추가", tags = {"Admin 소설"})
     @ApiResponses({
@@ -88,6 +90,8 @@ public class AdminNovelsController {
         novelsService.deleteNovels(id);
 
         novelsKafkaProducer.deleteNovels("deleteNovels", new NovelsDeleteKafkaDto(id));
+
+        episodeHistoryService.deleteEpisodeByNovelsId(id);
     }
 
     @Operation(summary = "소설 단건 조회", description = "소설 단건 조회, 조회할 소설 id url 전달", tags = {


### PR DESCRIPTION
1. 소설 내역 수정
   - 기존 : 소설별로 가장 최근 1개만 저장
   - 변경 : 읽은 내역 모두 저장, 조회할 때 소설별 가장 최신화 1개만 조회
2. 소설, uuid 별로 읽은 내역 모두 조회 추가 (읽은 에피소드 표시용)
3. episode 조회시 이전화, 다음화 정보 추가
   - prevId, prevFree, prevRead, nextId, nextFree, nextRead (이전화, 다음화 id, 유료인지, 읽었는지)
4. 소설, 에피소드 삭제시 읽은 내역에도 삭제